### PR TITLE
Ensure that boxes don't overlap when placing todo's in close proximity of each other (resolves #1)

### DIFF
--- a/lib/box-placement.typ
+++ b/lib/box-placement.typ
@@ -1,0 +1,47 @@
+// Given a set of box heights and the preferred positions for the boxes this function calculates the position for each box
+#let calculate-box-positions(boxes) = {
+  let total-height = boxes.map(box => box.height).sum()
+  
+  let positions = ()
+  // If the total height of the boxes is bigger than the page height, we don't have room to re-arrange the boxes based on their preferred position. Just start at the top and place them underneath each other
+  if total-height >= page.height {
+    let accumulated-height = 0mm
+    for box in boxes {
+      let top = accumulated-height
+      let bottom = top + box.height
+      positions.push((top: top, bottom: bottom))
+      accumulated-height = bottom
+    }
+  }
+  // If there is still room available, try to move as many boxes to their preferred position as possible
+  else {
+    // `slack` is the amount of free space we still have available to move around the boxes
+    let slack = page.height - total-height
+    // Start filling the page at the bottom with the last box and work upwards
+    let last-box-pos = page.height
+    for box in boxes.rev() {
+      let preferred-pos = box.preferred-pos.to-absolute() // We cannot compare pt to em, so we need to make the position absolute first
+      // `lowest-possible-pos` is the lowest position we can give the box to make it barely fit the available space
+      let lowest-possible-pos = last-box-pos - box.height
+      // `highest-possible-pos` is the highest possible postion we can give the box so the remaining boxes still barely fit on the remaining page (all slack would be used up in this case)
+      let highest-possible-pos = lowest-possible-pos - slack
+      let box-pos
+      // If the preferred position can be achieved, just give it to the box
+      if preferred-pos >= highest-possible-pos and preferred-pos <= lowest-possible-pos {
+        box-pos = preferred-pos
+      }
+      // If putting the box at its preferred position is impossible, move it down as much as possible to give the other boxes as much space as possible to move to their preferred positions
+      else {
+        box-pos = lowest-possible-pos
+      }
+      let top = box-pos
+      let bottom = top + box.height
+      positions.push((top: top, bottom: bottom))
+      last-box-pos = box-pos
+      // Track how much of the slack we've used up
+      slack -= lowest-possible-pos - box-pos
+    }
+    positions = positions.rev()
+  }
+  positions
+}

--- a/lib/todo.typ
+++ b/lib/todo.typ
@@ -39,7 +39,7 @@
 }
 
 #let side-todo(body, position) = {
-  context box({
+  box(context {
     let text-position = here().position()
 
     let side = position
@@ -79,8 +79,8 @@
     })
 
     let boxes = boxes.final()
-    
-    if boxes.len() > 0 { // For some reason there can be situations where box-positions == 0 which would make the code below fail. This might likely a bug, but I cannot tell why it happens
+
+    if boxes.len() > box-index { // The typst compiler will skip state updates during initial layout, leaving the list empty, leading to boxes.len() < box-index. To avoid compiler errors, we'll wait for the states to be updated before placing the boxes
       let box-positions = calculate-box-positions(boxes)
 
       // This place will shift the coordinate system so (0, 0) will address the top left corner of the page


### PR DESCRIPTION
This PR is a fix for #1. With this PR, boxes across a single page are tracked and moved apart from each other if they would overlap. The algorithm for box placement is fairly simple, but should work well enough in most situations.

This is the result produced by this PR when given the example of #1:
![grafik](https://github.com/user-attachments/assets/3ba90dc0-e20d-4abd-bbfd-295f57684a48)

There are a few flaws that I'm aware of, but I consider them all rather minor:

- All boxes should have the same distance between each other to produce an aesthetically pleasing result. This is usually achieved by the code, but if a todo box is placed at the beginning of paragraph, the first two boxes may end up being placed a bit too close to each other, as can be seen in the screenshot. I haven't fully understood why this happens, but apparently using `place(dx: -here().position(), dy: -here().position())` doesn't always create a coordinate system where `(0pt, 0pt)` is the top left corner of the document. This in turn causes the box to be mis-placed. I'm not entirely sure if this comes down to a misunderstanding on my part on how `here` and `place` work or if this might be a bug within typst itself.
- The placement algorithm might re-arrange the boxes quite significantly as a result of a small change in a todo note. This rarely happens (only if the currently edited box runs out of space; in that case boxes are moved a significant distance to make lots of room for the edited box). This will not be noticeable in the final render of the document, but is not pleasing to look at in an editor with live preview.
- Since the algorithm moves boxes out of the way quite aggressively, some boxes may end up much further away from their preferred position than necessary, with might produce undesirable placement in some cases. I think this could be improved by a smarter placement algorithm in the future, but for the time being I think suboptimal placement is preferable to overlapping boxes.

One last note for the code review: I'm fairly new to the typst ecosystem and as a result the code I've written might not be idiomatic typst.